### PR TITLE
Return all events - fixes #25

### DIFF
--- a/src/main/java/com/jrmcdonald/ifsc/Application.java
+++ b/src/main/java/com/jrmcdonald/ifsc/Application.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class Application {
-
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }

--- a/src/main/java/com/jrmcdonald/ifsc/config/RouterConfig.java
+++ b/src/main/java/com/jrmcdonald/ifsc/config/RouterConfig.java
@@ -8,16 +8,15 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
-import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
-import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
+import static org.springframework.web.reactive.function.server.RequestPredicates.*;
 
 @Configuration
 public class RouterConfig {
 
     @Bean
     public RouterFunction<ServerResponse> route(CalendarHandler calendarHandler) {
-        return RouterFunctions.route(
-                POST("/calendar").and(accept(MediaType.APPLICATION_JSON)),
-                calendarHandler::getCalendarByCategory);
+        return RouterFunctions
+                .route(GET("/calendar").and(accept(MediaType.APPLICATION_JSON)), calendarHandler::getCalendar)
+                .andRoute(POST("/calendar").and(accept(MediaType.APPLICATION_JSON)), calendarHandler::getCalendarByCategory);
     }
 }

--- a/src/main/java/com/jrmcdonald/ifsc/handler/CalendarHandler.java
+++ b/src/main/java/com/jrmcdonald/ifsc/handler/CalendarHandler.java
@@ -18,6 +18,12 @@ public class CalendarHandler {
 
     private final CalendarService calendarService;
 
+    public Mono<ServerResponse> getCalendar(ServerRequest serverRequest) {
+        return ServerResponse.ok()
+                .header("Content-Type", "text/calendar")
+                .body(calendarService.createCalendar(), String.class);
+    }
+
     public Mono<ServerResponse> getCalendarByCategory(ServerRequest serverRequest) {
         Mono<List<String>> categoriesMono = serverRequest.bodyToMono(new ParameterizedTypeReference<>() {});
         Mono<String> calendar = calendarService.createCalendar(categoriesMono);

--- a/src/main/java/com/jrmcdonald/ifsc/service/calendar/CalendarService.java
+++ b/src/main/java/com/jrmcdonald/ifsc/service/calendar/CalendarService.java
@@ -5,5 +5,6 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 public interface CalendarService {
+    Mono<String> createCalendar();
     Mono<String> createCalendar(Mono<List<String>> categoriesMono);
 }

--- a/src/main/java/com/jrmcdonald/ifsc/service/calendar/InternetCalendarService.java
+++ b/src/main/java/com/jrmcdonald/ifsc/service/calendar/InternetCalendarService.java
@@ -21,6 +21,13 @@ public class InternetCalendarService implements CalendarService {
     private final CompetitionsService competitionsService;
 
     @Override
+    public Mono<String> createCalendar() {
+        return competitionsService.findAll()
+                .flatMap(competitions -> Mono.just(competitions.getCompetitions()))
+                .flatMap(this::mapEventsToCalendar);
+    }
+
+    @Override
     public Mono<String> createCalendar(Mono<List<String>> categoriesMono) {
         return competitionsService.findByCategory(categoriesMono)
                 .flatMap(competitions -> Mono.just(competitions.getCompetitions()))

--- a/src/test/java/com/jrmcdonald/ifsc/handler/CalendarHandlerTest.java
+++ b/src/test/java/com/jrmcdonald/ifsc/handler/CalendarHandlerTest.java
@@ -2,7 +2,6 @@ package com.jrmcdonald.ifsc.handler;
 
 import com.jrmcdonald.ifsc.config.RouterConfig;
 import com.jrmcdonald.ifsc.service.calendar.CalendarService;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,24 +10,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.FluxExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
-
-import java.util.List;
-
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class CalendarHandlerTest {
 
     @Mock
@@ -56,21 +54,40 @@ class CalendarHandlerTest {
     void shouldExecuteService() {
         String expectedValue = "ICALENDAR_VALUE";
 
-        when(calendarService.createCalendar(any())).thenReturn(Mono.just(expectedValue));
+        when(calendarService.createCalendar()).thenReturn(Mono.just(expectedValue));
 
-        FluxExchangeResult<String> exchangeResult = client.post()
-                      .uri("/calendar")
-                      .bodyValue(singletonList("69"))
-                      .accept(MediaType.APPLICATION_JSON)
-                      .exchange()
-                      .expectHeader()
-                      .contentType("text/calendar")
-                      .returnResult(String.class);
+        FluxExchangeResult<String> exchangeResult = client.get()
+                .uri("/calendar")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .contentType("text/calendar")
+                .returnResult(String.class);
 
         StepVerifier.create(exchangeResult.getResponseBody()).assertNext(result -> {
             assertThat(result).isEqualTo(expectedValue);
-        })
-        .verifyComplete();
+        }).verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should execute service with categories")
+    void shouldExecuteServiceeWithCategories() {
+        String expectedValue = "ICALENDAR_VALUE";
+
+        when(calendarService.createCalendar(any())).thenReturn(Mono.just(expectedValue));
+
+        FluxExchangeResult<String> exchangeResult = client.post()
+                .uri("/calendar")
+                .bodyValue(singletonList("69"))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectHeader()
+                .contentType("text/calendar")
+                .returnResult(String.class);
+
+        StepVerifier.create(exchangeResult.getResponseBody()).assertNext(result -> {
+            assertThat(result).isEqualTo(expectedValue);
+        }).verifyComplete();
 
         verify(calendarService).createCalendar(categoriesMonoCaptor.capture());
 


### PR DESCRIPTION
This commit adds a GET endpoint to return an unfiltered set of calendar events.