### PR TITLE
build: use a personal access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'master'
+    paths-ignore:
+      - 'gradle.properties'
 
 jobs:
   release:
@@ -46,7 +48,7 @@ jobs:
         yarn audit
         yarn semantic-release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
     - name: Docker Release
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
Using a Personal Access Token with admin rights will allow pushes to
protected branches.