### PR TITLE
fix: publish correct jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,13 @@ test {
     classpath = sourceSets.main.output.classesDirs + classpath - files(jar.archiveFile)
 }
 
+configurations {
+    [apiElements, runtimeElements].each {
+        it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+        it.outgoing.artifact(bootJar)
+    }
+}
+
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
Gradle 6 requires special configuration to publish the bootJar. See https://docs.gradle.org/current/userguide/upgrading_version_6.html for details.