### PR TITLE
fix: allow ci to push to protected branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,16 @@ jobs:
         export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         export PR_NUMBER_OPT="-Dsonar.pullrequest.key=${PR_NUMBER}"
         echo "::set-env name=PR_NUMBER_OPT::${PR_NUMBER_OPT}"
+
+    - name: Set Branch Name
+      if: github.event_name != 'pull_request'
+      run: |
+        export BRANCH_NAME=$(git branch --show-current)
+        export BRANCH_NAME_OPT="-Dsonar.branch.name={BRANCH_NAME}"
+        echo "::set-env name=BRANCH_NAME_OPT::${BRANCH_NAME_OPT}"
       
     - name: Sonar
-      run: ./gradlew sonarqube -Dsonar.login=${SONAR_LOGIN} -Dsonar.branch.name=$(git branch --show-current) ${PR_NUMBER_OPT} --info
+      run: ./gradlew sonarqube -Dsonar.login=${SONAR_LOGIN} ${BRANCH_NAME_OPT} ${PR_NUMBER_OPT} --info
 
     - name: Docker Build
       run: ./gradlew jibDockerBuild -Djib.to.tags=latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 50
-    - run: |
-        git fetch --no-tags --prune --depth=1 origin master
+        fetch-depth: 0
+        persist-credentials: 'false'
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
By not persisting the checkout credentials we should force the use of
the PAT in the semantic-release command.